### PR TITLE
msi: use sdk: image for prerequisite

### DIFF
--- a/fluent-package/msi/Dockerfile
+++ b/fluent-package/msi/Dockerfile
@@ -29,7 +29,7 @@ RUN @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -I
 RUN \
   choco install -y git wixtoolset 7zip & \
   choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=System' && \
-  choco install -y msys2 --params /NoUpdate --version=20230318.0.0 && \
+  choco install -y msys2 --params /NoUpdate --version=20230526.0.0 && \
   choco install ruby -y --version=3.1.3.1 && \
   refreshenv && \
   ridk install 3 && \

--- a/fluent-package/msi/Dockerfile
+++ b/fluent-package/msi/Dockerfile
@@ -14,10 +14,13 @@
 #    limitations under the License.
 #
 
-# The "servercore" image cannot install DotNet3.5 (which is required by
-# wixtoolset) by chocolatey.
-ARG FROM=mcr.microsoft.com/dotnet/framework/runtime:3.5-windowsservercore-ltsc2019
+# The latest chocolatey requires .net 4.8, and wixtoolset requires .net 3.5,
+# To satisfy both of them without reboot, use sdk image.
+ARG FROM=mcr.microsoft.com/dotnet/framework/sdk:3.5-windowsservercore-ltsc2019
 FROM ${FROM}
+
+# Launch the following command as if cmd /S /C ...
+SHELL ["cmd", "/S", "/C"]
 
 # Install Chocolatey to set up toolchain
 RUN @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "[System.Net.ServicePointManager]::SecurityProtocol = 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"


### PR DESCRIPTION
wixtoolset: requrie .net 3.5
chocolatey: requrie .net 4.8

runtime:3.5 doesn't contain .net 4.8, and chocolatey try to install .net 4.8 during install process, as a result, it causes the following error:

 Please reboot the system and try to install/upgrade Chocolatey again.
At C:\Users\ContainerAdministrator\AppData\Local\Temp\chocolatey\chocoInstall\t ools\chocolateysetup.psm1:815 char:11
+           throw ".NET Framework 4.8 was installed, but a reboot is re ...
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (.NET Framework ...ocolatey ag
   ain.:String) [], RuntimeException
    + FullyQualifiedErrorId : .NET Framework 4.8 was installed, but a reboot i
   s required.