### PR TITLE
ci: fix empty base_ref error

### DIFF
--- a/.github/workflows/maintenance-bundle-update.yml
+++ b/.github/workflows/maintenance-bundle-update.yml
@@ -34,4 +34,5 @@ jobs:
           git add fluent-package/Gemfile.lock
           git commit --message "Update Gemfile.lock" --signoff
           git push origin $branch
-          gh pr create --base ${{ github.base_ref }} --title "Update Gemfile.lock" --body "Update Gemfile.lock by maintenance workflow"
+          $base_branch=echo $GITHUB_REF | %{$_ -Replace "refs/heads/", ""}
+          gh pr create --base $base_branch --title "Update Gemfile.lock" --body "Update Gemfile.lock by maintenance workflow"


### PR DESCRIPTION
Use GITHUB_REF which contains refs/heads/BRANCH_NAME