### PR TITLE
ci: force newer CMake policy

### DIFF
--- a/.github/workflows/maintenance-bundle-update.yml
+++ b/.github/workflows/maintenance-bundle-update.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           cd fluent-package
           gem install bundler:2.3.27
-          bundle _2.3.27_ update -j 4
+          CMAKE_FLAGS="-DCMAKE_POLICY_VERSION_MINIMUM=3.5" bundle _2.3.27_ update -j 4
       - name: Create Pull Request
         run: |
           $today=Get-Date -Format "yyyy-MM-dd-HHmmss"


### PR DESCRIPTION
newer CMake drops policy version < 3.5, so keeping build with older policy (e.g. cmetrics), raise border to 3.5 on windows-latest

  -----
  CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
    Compatibility with CMake < 3.5 has been removed from CMake.
    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.
    Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
  -- Configuring incomplete, errors occurred!
  ----- end of file -----
  *** extconf.rb failed ***